### PR TITLE
Improve error handling and update func.yaml syntax

### DIFF
--- a/func.yaml
+++ b/func.yaml
@@ -6,10 +6,7 @@ registry: ""
 image: docker.io/salaboy/level-2:latest
 imageDigest: sha256:2d75aa269786a02390dcc93749ed522ea4eea2147579234a6e01338599d7a4bc
 build: local
-git:
-  url: null
-  revision: null
-  contextdir: null
+git: {}
 builder: gcr.io/paketo-buildpacks/builder:base
 builders:
   base: gcr.io/paketo-buildpacks/builder:base
@@ -22,7 +19,9 @@ volumes: []
 buildEnvs: []
 envs:
 - name: REDIS_HOST
-  value: 10.200.130.188:6379
+  value: "" # <hostname>:<port>
+- name: REDIS_PASSWORD
+  value: ""
 annotations: {}
 options: {}
 labels: []

--- a/handle.go
+++ b/handle.go
@@ -5,18 +5,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/go-redis/redis"
+	"log"
 	"net/http"
 	"os"
 	"time"
 )
 
 type Answers struct {
-	SessionId string `json:"sessionId"`
-	OptionA bool `json:"optionA"`
-	OptionB bool `json:"optionB"`
-	OptionC bool `json:"optionC"`
-	OptionD bool `json:"optionD"`
-	RemainingTime int `json:"remainingTime"`
+	SessionId     string `json:"sessionId"`
+	OptionA       bool   `json:"optionA"`
+	OptionB       bool   `json:"optionB"`
+	OptionC       bool   `json:"optionC"`
+	OptionD       bool   `json:"optionD"`
+	RemainingTime int    `json:"remainingTime"`
 }
 
 type Score struct {
@@ -26,15 +27,15 @@ type Score struct {
 	LevelScore int
 }
 
-type GameTime struct{
+type GameTime struct {
 	GameTimeId string
-	SessionId string
-	Level string
-	Type string
-	Time      time.Time
+	SessionId  string
+	Level      string
+	Type       string
+	Time       time.Time
 }
 
-var redisHost = os.Getenv("REDIS_HOST")// This should include the port which is most of the time 6379
+var redisHost = os.Getenv("REDIS_HOST") // This should include the port which is most of the time 6379
 var redisPassword = os.Getenv("REDIS_PASSWORD")
 
 // Handle an HTTP Request.
@@ -53,18 +54,19 @@ func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
 	// respond to the client with the error message and a 400 status code.
 	err := json.NewDecoder(req.Body).Decode(&answers)
 	if err != nil {
+		log.Println("Error while deserializing Answers: ", err)
 		http.Error(res, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	if answers.OptionA == true {
-		points= points + 10
+		points = points + 10
 	}
 	if answers.OptionB == true {
-		points= points + 8
+		points = points + 8
 	}
 	if answers.OptionC == true {
-		points= points + 8
+		points = points + 8
 	}
 	if answers.OptionD == true {
 		//you shouldn't get any points ;)
@@ -79,13 +81,17 @@ func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
 	score.Time = time.Now()
 	scoreJson, err := json.Marshal(score)
 	if err != nil {
-		fmt.Println(err)
+		log.Println("Error while serializing Score: ", err)
+		http.Error(res, err.Error(), http.StatusBadRequest)
+		return
 	}
 	err = client.RPush("score-"+answers.SessionId, string(scoreJson)).Err()
 	// if there has been an error setting the value
 	// handle the error
 	if err != nil {
-		fmt.Println(err)
+		log.Println("Error while pushing Score to Redis: ", err)
+		http.Error(res, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	gt := GameTime{
@@ -98,6 +104,7 @@ func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
 
 	gameTimeJson, err := json.Marshal(gt)
 	if err != nil {
+		log.Println("Error while serializing GameTime: ", err)
 		http.Error(res, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -106,6 +113,7 @@ func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
 	// if there has been an error setting the value
 	// handle the error
 	if err != nil {
+		log.Println("Error while pushing GameTime to Redis: ", err)
 		http.Error(res, err.Error(), http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
It looks like the latest version of the func plugin (0.22.0) complains about the non-string git information and doesn't recognize the contextdir property. I updated the func.yaml file based on how the plugin itself modified it.

Also, I thought it could be useful to log more details when the serialisation and Redis operations fail.